### PR TITLE
Fix username validation for CommonName.

### DIFF
--- a/api/server/router/acme/newcert.go
+++ b/api/server/router/acme/newcert.go
@@ -96,9 +96,9 @@ func NewCertHandle(c echo.Context) error {
 			return api.JSON(c, http.StatusBadRequest, r)
 		}
 
-		// if type is client, CN should not be a FQDN
-		if err = validation.IsValidFQDN(csr.CR.Subject.CommonName); err != nil {
-			r := jsonapi.NewErrorResponse(12000, "Cannot use FQDN for client CN")
+		// if type is client, CN should be valid name
+		if err = validation.IsValidName(csr.CR.Subject.CommonName); err != nil {
+			r := jsonapi.NewErrorResponse(12000, "username is not valid")
 
 			return api.JSON(c, http.StatusBadRequest, r)
 		}


### PR DESCRIPTION
Fixes an issue with usernames containing numbers.

The IsValidFQDN code checks if the last part of its argument only contains ascii letters and fails otherwise.
As usernames only have one part any name containing any other characters will fail.

I should say that I haven't been able to test this fix.